### PR TITLE
refactor: DRY evidence tab page wrapper

### DIFF
--- a/evidence_tab.php
+++ b/evidence_tab.php
@@ -28,6 +28,7 @@ include_once('./include/auth.php');
 include_once('./lib/snmp.php');
 include_once('./plugins/evidence/include/functions.php');
 include_once('./plugins/evidence/include/arrays.php');
+include_once('./plugins/evidence/include/ui_helpers.php');
 
 set_default_action();
 
@@ -42,18 +43,12 @@ switch (get_request_var('action')) {
 		break;
 
 	case 'find':
-		general_header();
-		evidence_display_form();
-		evidence_find();
-		bottom_footer();
+		evidence_render_tab_page('evidence_find');
 
 		break;
 
         default:
-		general_header();
-		evidence_display_form();
-		evidence_stats();
-		bottom_footer();
+		evidence_render_tab_page('evidence_stats');
 
 		break;
 }
@@ -259,5 +254,4 @@ function evidence_stats() {
 	print 'Vendor specific data: ' . $ven . '<br/>';
 	print 'Oldest record: ' . $old . '<br/>';
 }
-
 

--- a/include/ui_helpers.php
+++ b/include/ui_helpers.php
@@ -1,0 +1,20 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2021-2024 Petr Macek                                      |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ +-------------------------------------------------------------------------+
+ */
+
+if (!function_exists('evidence_render_tab_page')) {
+	function evidence_render_tab_page($content_renderer) {
+		general_header();
+		evidence_display_form();
+		call_user_func($content_renderer);
+		bottom_footer();
+	}
+}

--- a/include/ui_helpers.php
+++ b/include/ui_helpers.php
@@ -11,10 +11,10 @@
  */
 
 if (!function_exists('evidence_render_tab_page')) {
-	function evidence_render_tab_page($content_renderer) {
+	function evidence_render_tab_page(callable $content_renderer) {
 		general_header();
 		evidence_display_form();
-		call_user_func($content_renderer);
+		$content_renderer();
 		bottom_footer();
 	}
 }

--- a/tests/test_tab_wrapper.php
+++ b/tests/test_tab_wrapper.php
@@ -1,0 +1,55 @@
+<?php
+
+require_once __DIR__ . '/../include/ui_helpers.php';
+
+$events = [];
+
+function general_header() {
+	global $events;
+	$events[] = 'header';
+}
+
+function evidence_display_form() {
+	global $events;
+	$events[] = 'form';
+}
+
+function bottom_footer() {
+	global $events;
+	$events[] = 'footer';
+}
+
+function evidence_tab_test_content() {
+	global $events;
+	$events[] = 'content';
+}
+
+function assert_same($expected, $actual, $message) {
+	if ($expected !== $actual) {
+		fwrite(STDERR, $message . PHP_EOL);
+		fwrite(STDERR, 'Expected: ' . json_encode($expected) . PHP_EOL);
+		fwrite(STDERR, 'Actual:   ' . json_encode($actual) . PHP_EOL);
+		exit(1);
+	}
+}
+
+evidence_render_tab_page('evidence_tab_test_content');
+assert_same(['header', 'form', 'content', 'footer'], $events, 'Tab helper should render wrapper in correct order.');
+
+$source = file_get_contents(__DIR__ . '/../evidence_tab.php');
+if ($source === false) {
+	fwrite(STDERR, "Unable to read evidence_tab.php\n");
+	exit(1);
+}
+
+if (strpos($source, "evidence_render_tab_page('evidence_find');") === false) {
+	fwrite(STDERR, "Expected find action to use evidence_render_tab_page().\n");
+	exit(1);
+}
+
+if (strpos($source, "evidence_render_tab_page('evidence_stats');") === false) {
+	fwrite(STDERR, "Expected default action to use evidence_render_tab_page().\n");
+	exit(1);
+}
+
+echo "OK\n";

--- a/tests/test_tab_wrapper.php
+++ b/tests/test_tab_wrapper.php
@@ -33,6 +33,13 @@ function assert_same($expected, $actual, $message) {
 	}
 }
 
+function assert_regex($pattern, $subject, $message) {
+	if (!preg_match($pattern, $subject)) {
+		fwrite(STDERR, $message . PHP_EOL);
+		exit(1);
+	}
+}
+
 evidence_render_tab_page('evidence_tab_test_content');
 assert_same(['header', 'form', 'content', 'footer'], $events, 'Tab helper should render wrapper in correct order.');
 
@@ -42,14 +49,16 @@ if ($source === false) {
 	exit(1);
 }
 
-if (strpos($source, "evidence_render_tab_page('evidence_find');") === false) {
-	fwrite(STDERR, "Expected find action to use evidence_render_tab_page().\n");
-	exit(1);
-}
+assert_regex(
+	"/evidence_render_tab_page\\(\\s*'evidence_find'\\s*\\)\\s*;/",
+	$source,
+	"Expected find action to use evidence_render_tab_page()."
+);
 
-if (strpos($source, "evidence_render_tab_page('evidence_stats');") === false) {
-	fwrite(STDERR, "Expected default action to use evidence_render_tab_page().\n");
-	exit(1);
-}
+assert_regex(
+	"/evidence_render_tab_page\\(\\s*'evidence_stats'\\s*\\)\\s*;/",
+	$source,
+	"Expected default action to use evidence_render_tab_page()."
+);
 
 echo "OK\n";


### PR DESCRIPTION
## Summary
Implements issue #22 by removing duplicated evidence tab page wrapper logic.

### Changes
- added shared helper `evidence_render_tab_page()` in `include/ui_helpers.php`
- updated `evidence_tab.php`:
  - `find` action now uses `evidence_render_tab_page('evidence_find')`
  - default action now uses `evidence_render_tab_page('evidence_stats')`
- added regression test: `tests/test_tab_wrapper.php`

## Validation
- `php -l evidence_tab.php`
- `php -l include/ui_helpers.php`
- `php -l tests/test_tab_wrapper.php`
- `php tests/test_tab_wrapper.php`

## Issue
Closes #22
